### PR TITLE
Updated dockerfile to support latest version

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,28 @@
+FROM node:8.11.2
+LABEL maintainer="Rocket.Chat Team <buildmaster@rocket.chat>"
+
+RUN useradd hubot -m
+USER hubot
+COPY ./bin /home/hubot/bin/
+COPY ./scripts /home/hubot/scripts/
+COPY package.json /home/hubot/package.json
+
+USER root
+RUN chown hubot:hubot -R /home/hubot/bin 
+RUN chmod +x /home/hubot/bin/hubot
+
+WORKDIR /home/hubot
+USER hubot
+
+RUN npm install
+
+ENV BOT_NAME "rocketbot" 
+ENV BOT_OWNER "No owner specified"	
+ENV BOT_DESC "Hubot with rocketbot adapter"
+ENV ROCKETCHAT_URL "localhost"
+ENV ROCKETCHAT_USER "bot"
+ENV ROCKETCHAT_PASS "bot"
+ENV EXTERNAL_SCRIPTS=hubot-diagnostics,hubot-help,hubot-rules
+
+# bin/hubot -n $BOT_NAME -a rocketchat
+CMD npm run local

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "coffeescript": "^2.2.2",
     "hubot": "3",
-    "hubot-rocketchat": "rocketchat/hubot-rocketchat"
+    "hubot-rocketchat": "2.0.0"
   },
   "devDependencies": {
     "dotenv": "^5.0.1"


### PR DESCRIPTION
I am a still getting up to speed with Docker so take that into account when reviewing, but everything seems to work. 

I decided to skip the previous entry point but I left the line in so it can be uncommented by those still using coffeescript. 

````
# bin/hubot -n $BOT_NAME -a rocketchat
CMD npm run local
````

Also I had to change `package.json` to pull down hubot-rocketchat as it wasn't being found locally:

`"hubot-rocketchat": "2.0.0"`

Also there is a problem with the adapter as there is no support in the latest `hubot-rocketchat` for the RC environment variables. I have made a fairly hacky fix and will post a PR in a sec.
