### PR TITLE
Add protocol to ROCKETCHAT_URL to prevent connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 Create a _.env_ file with content:
 
 ```
-export ROCKETCHAT_URL=myserver.com
+export ROCKETCHAT_URL=https://myserver.com
 export ROCKETCHAT_USER=mybotuser
 export ROCKETCHAT_PASSWORD=mypassword
 export ROCKETCHAT_ROOM=general


### PR DESCRIPTION
When using Hubot against Cloud instances the following error shows up when the protocol is omitted in the `ROCKETCHAT_URL` env variable.

This adds the protocol prefix to the README.md to prevent similiar issues in the future.

See also: RocketChat/hubot-rocketchat-boilerplate#6